### PR TITLE
Add an authenticated proxy configuration option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ branches:
   only:
     - main
     - /^v\d/
+    - /PN-2612/
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,5 @@ branches:
   only:
     - main
     - /^v\d/
-    - /PN-2612/
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 2.3.0
+
+Added: Proxy support for Relay Agent.
+
 ## Release 2.2.0
 
 Added: The Puppet Enterprise orchestrator backend now supports dispatching tasks and plans.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the Relay SaaS event trigger API. Workflows may subscribe to the triggers and
 decide whether to run based on the run status and log lines.
 
 Second, it runs a Relay agent on your puppetserver which can be used to trigger
-puppet runs on specific nodes, without requiring inbound connectivity from 
+puppet runs on specific nodes, without requiring inbound connectivity from
 Relay to your puppetserver.
 
 ## Setup
@@ -56,12 +56,12 @@ triggers:
 You'll then copy the access token from the Triggers section of the workflow page:
 ![ Copying access token from the workflow page](https://github.com/puppetlabs/puppetlabs-relay/raw/main/media/push-trigger.png)
 
-To see an example of a Relay workflow that uses this trigger, see 
-[the puppet-shutdown-ec2 example workflow](https://github.com/puppetlabs/relay-workflows/tree/master/puppet-shutdown-ec2), which watches for unexpected changes to the `sudoers` file 
+To see an example of a Relay workflow that uses this trigger, see
+[the puppet-shutdown-ec2 example workflow](https://github.com/puppetlabs/relay-workflows/tree/master/puppet-shutdown-ec2), which watches for unexpected changes to the `sudoers` file
 and shuts down affected nodes for investigation.
 
 To use the Relay agent capability, which enables you to trigger
-Puppet runs from Relay workflows, you'll also need to set up a 
+Puppet runs from Relay workflows, you'll also need to set up a
 Puppet connection in the Relay app. This will generate a separate
 token that the Relay agent, running on your puppetserver, uses to
 authenticate run requests from the service. To configure this, go
@@ -84,8 +84,8 @@ host with the `relay` class. This class will:
    connection token
 1. set up the Relay agent configuration and service to run automatically
 
-For Puppet Enterprise, add the `relay` class to the Node Classifier group 
-that contains your puppetmasters. Open source Puppet classification will 
+For Puppet Enterprise, add the `relay` class to the Node Classifier group
+that contains your puppetmasters. Open source Puppet classification will
 vary per local setup, but you'll need to make sure the hosts running
 puppetservers also are classified with the `relay` class.
 
@@ -93,7 +93,7 @@ We recommend using hiera to store the configuration for the Relay module,
 and specifically to use hiera-eyaml to prevent hardcoding the tokens in
 your configuration. For more information on hiera-eyaml, see the [hiera-eyaml documentation on Github](https://github.com/voxpupuli/hiera-eyaml). You'll need to hiera keys with the eyaml-encrypted values of the Relay push token at a minimum.
 Additionally, if you're using the Relay agent functionality, add the token for
-the Puppet connection and either the PE Orchestrator access token or 
+the Puppet connection and either the PE Orchestrator access token or
 a ssh key to enable Bolt to access nodes.
 
 ```yaml
@@ -123,12 +123,12 @@ relay::backend_options:
 
 ## Example #1: Trigger Relay workflow from Puppet run
 
-Run the Puppet agent (either in noop or enforce mode) to trigger a Relay workflow. 
+Run the Puppet agent (either in noop or enforce mode) to trigger a Relay workflow.
 
 If the Relay report processor detects an out-of-sync resource, with the agent
 in either no-op or enforce mode, it will send the report details to the Relay
 push API, authenticated with the `relay_trigger_token` we configured above.
-The workflow can then take action using any combination the steps from the 
+The workflow can then take action using any combination the steps from the
 [Relay integration library](https://relay.sh/library/).
 
 The example [puppet-shutdown-ec2](https://github.com/puppetlabs/relay-workflows/tree/master/puppet-shutdown-ec2) module looks for unexpected changes in sudoers and
@@ -144,8 +144,8 @@ to take, and will then use the transport configured in `backend_options`
 parameters to kick off Puppet agent runs on the nodes the workflow
 specifies.
 
-To set this up, add a Puppet connection in Relay, then add a step like 
-the following to your Relay workflow. Make sure the `name` field in the 
+To set this up, add a Puppet connection in Relay, then add a step like
+the following to your Relay workflow. Make sure the `name` field in the
 `!Connection` value matches the name you set at creation time. In this
 example, the workflow has a parameter `host` which the user supplies;
 instead of `!Parameter host`, you could use the [output of an earlier step](https://relay.sh/docs/using-workflows/passing-data-into-workflow-steps/) or
@@ -274,6 +274,31 @@ Type: String
 The group the Puppet service and Relay agent run under.
 
 Default: `"pe-puppet"` in Puppet Enterprise, `"puppet"` otherwise.
+
+##### `proxy_host`
+
+Type: String
+
+The proxy hostname or IP address. The Relay agent will use this proxy to connect to Relay.
+
+##### `proxy_port`
+
+Type: Integer
+
+The proxy port to connect to on the `proxy_host`.
+
+##### `proxy_user`
+
+Type: String
+
+The user for authenticating to the proxy. Do not specify this parameter if the proxy does not require authentication.
+
+##### `proxy_password`
+
+Type: Sensitive[String]
+
+The password for authenticating to the proxy. Do not specify this parameter if the proxy does not require authentication.
+
 
 ### Report processor event
 

--- a/lib/puppet_x/relay/agent/context.rb
+++ b/lib/puppet_x/relay/agent/context.rb
@@ -16,7 +16,7 @@ module PuppetX
 
         # @return [Util::HTTP::RelayAPI]
         def relay_api
-          Util::HTTP::RelayAPI.new(settings[:relay_api_url], settings[:relay_connection_token])
+          Util::HTTP::RelayAPI.new(settings[:relay_api_url], settings[:relay_connection_token], settings)
         end
 
         # @return [Backend::Base]

--- a/lib/puppet_x/relay/util/http/client.rb
+++ b/lib/puppet_x/relay/util/http/client.rb
@@ -7,8 +7,14 @@ module PuppetX
         class Client
           def initialize(base_url, settings = nil)
             @base_url = base_url
+
             @proxy_host = settings[:proxy_host] if settings
             @proxy_port = settings[:proxy_port] if settings
+            raise 'proxy_port should be set if proxy_host is defined' if @proxy_port.nil? && !@proxy_host.nil?
+
+            # restore default behaviour if @proxy_host is not set
+            @proxy_host = :ENV if @proxy_host.nil?
+
             @proxy_user = settings[:proxy_user] if settings
             @proxy_password = settings[:proxy_password] if settings
           end

--- a/lib/puppet_x/relay/util/http/client.rb
+++ b/lib/puppet_x/relay/util/http/client.rb
@@ -5,8 +5,12 @@ module PuppetX
     module Util
       module HTTP
         class Client
-          def initialize(base_url)
+          def initialize(base_url, settings = nil)
             @base_url = base_url
+            @proxy_host = settings[:proxy_host] if settings
+            @proxy_port = settings[:proxy_port] if settings
+            @proxy_user = settings[:proxy_user] if settings
+            @proxy_password = settings[:proxy_password] if settings
           end
 
           # @param verb [Symbol]
@@ -21,7 +25,7 @@ module PuppetX
 
             update_request!(req)
 
-            http = Net::HTTP.new(uri.host, uri.port)
+            http = Net::HTTP.new(uri.host, uri.port, @proxy_host, @proxy_port, @proxy_user, @proxy_password)
             http.use_ssl = uri.scheme == 'https'
             http.verify_mode = OpenSSL::SSL::VERIFY_PEER
             update_http!(http)

--- a/lib/puppet_x/relay/util/http/relay_api.rb
+++ b/lib/puppet_x/relay/util/http/relay_api.rb
@@ -12,8 +12,8 @@ module PuppetX
         class RelayAPI < Client
           class MissingTokenError < StandardError; end
 
-          def initialize(base_url, token)
-            super(base_url)
+          def initialize(base_url, token, settings)
+            super(base_url, settings)
             @token = token
 
             raise MissingTokenError unless @token

--- a/lib/puppet_x/relay/util/settings.rb
+++ b/lib/puppet_x/relay/util/settings.rb
@@ -39,6 +39,10 @@ module PuppetX
           backend_bolt_ssh_password: nil,
           backend_bolt_ssh_host_key_check: true,
           backend_ssh_command: ['ssh'],
+          proxy_host: nil,
+          proxy_port: nil,
+          proxy_user: nil,
+          proxy_password: nil,
         }.freeze
 
         def_delegators "#{name}::DEFAULTS", :[], :each

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,10 @@ class relay (
   Optional[Stdlib::HTTPUrl] $relay_api_url = undef,
   Optional[Sensitive[String]] $relay_connection_token = undef,
   Optional[Variant[Array[Sensitive[String]], Sensitive[String]]] $relay_trigger_token = undef,
+  Optional[String] $proxy_host = undef,
+  Optional[Integer] $proxy_port = undef,
+  Optional[String] $proxy_user = undef,
+  Optional[Sensitive[String]] $proxy_password = undef,
 ) {
   $settings_file = "${settings::confdir}/relay.yaml"
   $state_file = "${settings::statedir}/relay.json"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,6 +13,10 @@ class relay::install {
       relay_trigger_token    => $relay::relay_trigger_token,
       backend                => $relay::backend,
       backend_options        => $relay::backend_options,
+      proxy_host             => $relay::proxy_host,
+      proxy_port             => $relay::proxy_port,
+      proxy_user             => $relay::proxy_user,
+      proxy_password         => $relay::proxy_password,
     })),
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-relay",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "Hunter Haugen",
   "summary": "Configure Puppet to work with Relay",
   "license": "Apache-2.0",

--- a/spec/unit/puppet_x/relay/util/http/client_spec.rb
+++ b/spec/unit/puppet_x/relay/util/http/client_spec.rb
@@ -1,0 +1,13 @@
+require 'puppet_x/relay/util/http/client'
+
+describe 'Relay HTTP Client' do
+  it 'does not accept empty proxy port if proxy host is set' do
+    expect {
+      PuppetX::Relay::Util::HTTP::Client.new('http://some.url', proxy_host: 'somehost', proxy_port: nil)
+    }.to raise_error('proxy_port should be set if proxy_host is defined')
+  end
+  it 'sets proxy host to :ENV if empty' do
+    client = PuppetX::Relay::Util::HTTP::Client.new('http://some.url', proxy_host: nil)
+    expect(client.instance_variable_get(:@proxy_host)).to eq :ENV
+  end
+endw

--- a/spec/unit/puppet_x/relay/util/http/client_spec.rb
+++ b/spec/unit/puppet_x/relay/util/http/client_spec.rb
@@ -10,4 +10,4 @@ describe 'Relay HTTP Client' do
     client = PuppetX::Relay::Util::HTTP::Client.new('http://some.url', proxy_host: nil)
     expect(client.instance_variable_get(:@proxy_host)).to eq :ENV
   end
-endw
+end

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -6,6 +6,11 @@
   Optional[Variant[Array[Sensitive[String]], Sensitive[String]]] $relay_trigger_token,
   String $backend,
   Hash[String, Variant[Data, Sensitive[Data]]] $backend_options,
+  Optional[String] $proxy_host,
+  Optional[Integer] $proxy_port,
+  Optional[String] $proxy_user,
+  Optional[Sensitive[String]] $proxy_password,
+
 | -%>
 # This file is managed by Puppet. DO NOT EDIT.
 <%= to_yaml(({
@@ -29,4 +34,9 @@
       default => $value,
     },
   ]
+} + {
+  'proxy_host' => $proxy_host,
+  'proxy_port' => $proxy_port,
+  'proxy_user' => $proxy_user,
+  'proxy_password' => $proxy_password.then |$p| { $p.unwrap },
 })).filter |$key, $value| { $value =~ NotUndef }) -%>


### PR DESCRIPTION
This PR adds the following proxy configuration parameters to the `relay` class:

* `proxy_host`
* `proxy_port`
* `proxy_user`
* `proxy_password`

These proxy settings, if set, are used by the Relay agent for connections to the Relay API.

This PR does not include support for using PE-configured proxy settings.