### PR TITLE
Fix/relay api params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 2.3.1
+
+Fixed: Relay API client changes in previous release made it incompatible with the Report Processor. This is now fixed.
+
 ## Release 2.3.0
 
 Added: Proxy support for Relay Agent.

--- a/lib/puppet_x/relay/util/http/relay_api.rb
+++ b/lib/puppet_x/relay/util/http/relay_api.rb
@@ -12,7 +12,7 @@ module PuppetX
         class RelayAPI < Client
           class MissingTokenError < StandardError; end
 
-          def initialize(base_url, token, settings)
+          def initialize(base_url, token, settings=nil)
             super(base_url, settings)
             @token = token
 

--- a/lib/puppet_x/relay/util/http/relay_api.rb
+++ b/lib/puppet_x/relay/util/http/relay_api.rb
@@ -12,7 +12,7 @@ module PuppetX
         class RelayAPI < Client
           class MissingTokenError < StandardError; end
 
-          def initialize(base_url, token, settings=nil)
+          def initialize(base_url, token, settings = nil)
             super(base_url, settings)
             @token = token
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-relay",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": "Hunter Haugen",
   "summary": "Configure Puppet to work with Relay",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixed: Relay API client changes in the previous release made it incompatible with the Report Processor. This is now fixed.
