### PR TITLE
Set lookup options for relay::*token by default

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,8 @@
 ---
+lookup_options:
+  "^relay::.*token":
+    convert_to: "Sensitive"
+
 relay::backend: bolt
 relay::backend_options: {}
 relay::puppet_service: puppetserver


### PR DESCRIPTION
We don't need users to specify this in their Hiera data configuration when we can specify the appropriate lookup options right here in the module. Users will then not need to know about or specify appropriate lookup options themselves; they can just specify e.g. `relay::relay::relay_connection_token`, blissfully unaware of the pedantic UX of "lookup_options", which practically no one knows about or wants to know about and should be automatic anyway.

This is a "drive-by" PR; docs changes could go along with this too. We shouldn't need to document setting lookup_options anymore after this change.