### PR TITLE
PN-2724 Add run_results to run state and send it back to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 Added: The agent now provides the results of the task, plan and puppet runs back to the API.
 Added: Minor documentation changes.
 
+Fixed: Resolved an issue where the Relay agent incorrectly looked up plan jobs in the Orchestrator.
+
 ## Release 2.3.2
 
 Fixed: Relay API client changes in previous release made it incompatible with the Report Processor. This is now fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 2.4.0
+
+Added: The agent now provides the results of the task, plan and puppet runs back to the API.
+Added: Minor documentation changes.
+
 ## Release 2.3.2
 
 Fixed: Relay API client changes in previous release made it incompatible with the Report Processor. This is now fixed.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Relay to your puppetserver.
 ### Requirements
 
 You must already have a puppetserver to which puppet agents submit reports and
-that can connect to the internet. Because you'll need to store access tokens
+that can connect to the internet (optionally through a proxy).
+Because you'll need to store access tokens
 for Relay, we strongly recommend using eyaml to encrypt the tokens as hiera keys.
 
 You must also have a Relay account registered. You can sign up for free at
@@ -85,13 +86,15 @@ host with the `relay` class. This class will:
 1. set up the Relay agent configuration and service to run automatically
 
 For Puppet Enterprise, add the `relay` class to the Node Classifier group
-that contains your puppetmasters. Open source Puppet classification will
+that contains your primary server. Open source Puppet classification will
 vary per local setup, but you'll need to make sure the hosts running
 puppetservers also are classified with the `relay` class.
 
 We recommend using hiera to store the configuration for the Relay module,
 and specifically to use hiera-eyaml to prevent hardcoding the tokens in
-your configuration. For more information on hiera-eyaml, see the [hiera-eyaml documentation on Github](https://github.com/voxpupuli/hiera-eyaml). You'll need to hiera keys with the eyaml-encrypted values of the Relay push token at a minimum.
+your configuration. For more information on hiera-eyaml,
+see the [hiera-eyaml documentation on Github](https://github.com/voxpupuli/hiera-eyaml).
+You'll need to hiera keys with the eyaml-encrypted values of the Relay push token at a minimum.
 Additionally, if you're using the Relay agent functionality, add the token for
 the Puppet connection and either the PE Orchestrator access token or
 a ssh key to enable Bolt to access nodes.
@@ -115,7 +118,6 @@ relay::backend_options:
   password: >
     ENC[PKCS7,.....]
 ```
-
 
 ## Example #1: Trigger Relay workflow from Puppet run
 
@@ -236,6 +238,8 @@ For backend `"orchestrator"`:
   slash in the URL. Default: `"https://{puppetserver}:8143/orchestrator/v1/"`
 * `token`: The RBAC token to use to access the orchestrator API. Sensitive.
   **Required.**
+  See [PE RBAC documentation](https://puppet.com/docs/pe/2021.2/rbac_token_auth_intro.html)
+  for more information on PE RBAC tokens.
 
 For backend `"bolt"`:
 

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -124,7 +124,11 @@ module PuppetX
             new_state =
               case data['state']
               when 'finished', 'failed'
-                run.state.to_complete(outcome: data['state'])
+                resp = @orchestrator_api.get("jobs/#{run.state.job_id}/nodes")
+                resp_json = JSON.parse(resp.body)
+                run_results = resp_json['items']
+                Puppet.debug("Run results: #{run_results}")
+                run.state.to_complete(outcome: data['state'], run_results: run_results)
               else
                 run.state.to_in_progress(schedule.next_update_before)
               end

--- a/lib/puppet_x/relay/agent/model/state.rb
+++ b/lib/puppet_x/relay/agent/model/state.rb
@@ -29,6 +29,9 @@ module PuppetX
           attr_reader :outcome
 
           # @return [String]
+          attr_reader :run_results
+
+          # @return [String]
           attr_reader :job_id
 
           # @return [Time]
@@ -45,13 +48,15 @@ module PuppetX
           end
 
           # @param outcome [String]
+          # @param run_results [String]
           # @return [self]
-          def to_complete(outcome: nil)
+          def to_complete(outcome: nil, run_results: nil)
             raise InvalidTransitionError, "Cannot transition status to complete from #{status}" unless [:pending, :in_progress].include? status
 
             upd = dup
             upd.instance_variable_set(:@status, :complete)
             upd.instance_variable_set(:@outcome, outcome)
+            upd.instance_variable_set(:@run_results, run_results)
             upd.instance_variable_set(:@next_update_before, nil)
             upd
           end
@@ -74,6 +79,7 @@ module PuppetX
             {
               'status' => status.to_s.tr('_', '-'),
               'outcome' => outcome,
+              'run_results' => run_results,
               'job_id' => job_id,
               'next_update_before' => (next_update_before.utc.iso8601 unless next_update_before.nil?),
               'updated_at' => (updated_at.utc.iso8601 unless updated_at.nil?),

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-relay",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "author": "Hunter Haugen",
   "summary": "Configure Puppet to work with Relay",
   "license": "Apache-2.0",


### PR DESCRIPTION
This change adds the `run_results` state field to runs (only for PE orchestrator backend, and only for plan and task runs).