### PR TITLE
PN-2810 - Report PE orchestrator errors

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
   symlinks:
     relay: "#{source_dir}"
   repositories:
-    provision: 'git://github.com/puppetlabs/provision.git'
+    provision: 'https://github.com/puppetlabs/provision.git'
   forge_modules:
     facts:
       repo: "puppetlabs-facts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 2.5.0
+
+Added: If an orchestrator error occurs during a job run, the agent now returns the error message as `run_results` with status `error`.
+
 ## Release 2.4.0
 
 Added: The agent now provides the results of the task, plan and puppet runs back to the API.

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -47,8 +47,8 @@ module PuppetX
             })
             run_results = { 
               error: "Failed to send request to orchestrator API",
-              message: {e.message},
-              response: {e.response.body}
+              message: e.message,
+              response: JSON.parse(e.response.body)
             }
             new_state = run.state.to_complete(outcome: 'failure', run_results: run_results)
             run.with_state(new_state)

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -48,7 +48,7 @@ module PuppetX
             begin
               result = JSON.parse(e.response.body)
             rescue JSON::ParserError
-              result = e.response.body
+              result = { msg: e.response.body }
             end
             new_state = run.state.to_complete(outcome: 'error', run_results: { result: result })
             run.with_state(new_state)

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -45,7 +45,14 @@ module PuppetX
               message: e.message,
               body: e.response.body,
             })
-            raise
+            run_results = { 
+              error: "Failed to send request to orchestrator API",
+              message: {e.message},
+              response: {e.response.body}
+            }
+            new_state = run.state.to_complete(outcome: 'failure', run_results: run_results)
+            run.with_state(new_state)
+            # raise
           end
 
           private

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -45,7 +45,11 @@ module PuppetX
               message: e.message,
               body: e.response.body,
             })
-            result = JSON.parse(e.response.body) rescue e.response.body
+            begin
+              result = JSON.parse(e.response.body)
+            rescue JSON::ParserError
+              result = e.response.body
+            end
             new_state = run.state.to_complete(outcome: 'error', run_results: { result: result })
             run.with_state(new_state)
           rescue Net::HTTPError, Net::HTTPRetriableError, Net::HTTPServerException, Net::HTTPFatalError => e

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -45,10 +45,10 @@ module PuppetX
               message: e.message,
               body: e.response.body,
             })
-            run_results = { 
-              error: "Failed to send request to orchestrator API",
+            run_results = {
+              error: 'Failed to send request to orchestrator API',
               message: e.message,
-              response: JSON.parse(e.response.body)
+              response: JSON.parse(e.response.body),
             }
             new_state = run.state.to_complete(outcome: 'failure', run_results: run_results)
             run.with_state(new_state)

--- a/lib/puppet_x/relay/agent/backend/orchestrator.rb
+++ b/lib/puppet_x/relay/agent/backend/orchestrator.rb
@@ -40,7 +40,7 @@ module PuppetX
                 raise NotImplementedError
               end
             end
-          rescue Net::HTTPClientError => e
+          rescue Net::HTTPClientError, Net::HTTPServerException => e
             Puppet.warning(_('Failed to send request to orchestrator API: %{message}, response: %{body}') % {
               message: e.message,
               body: e.response.body,
@@ -52,7 +52,7 @@ module PuppetX
             end
             new_state = run.state.to_complete(outcome: 'error', run_results: { result: result })
             run.with_state(new_state)
-          rescue Net::HTTPError, Net::HTTPRetriableError, Net::HTTPServerException, Net::HTTPFatalError => e
+          rescue Net::HTTPError, Net::HTTPRetriableError, Net::HTTPFatalError => e
             Puppet.warning(_('Failed to send request to orchestrator API: %{message}, response: %{body}') % {
               message: e.message,
               body: e.response.body,

--- a/lib/puppet_x/relay/agent/job/exec.rb
+++ b/lib/puppet_x/relay/agent/job/exec.rb
@@ -71,14 +71,14 @@ module PuppetX
                   message: e.message,
                 }
                 Puppet.log_exception(e, message)
-                @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: exception))
+                @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: { result: { msg: message } }))
               rescue StandardError => e
                 message = _('Run %{id} encountered an error during execution: %{message} (%{retries} retries remaining)') % { id: @run.id, message: e.message, retries: @retries }
                 Puppet.log_exception(e, message)
 
                 if (@retries -= 1) < 0
                   Puppet.warning(_('Retries exhausted for run %{id}, transitioning to complete with error outcome') % { id: @run.id })
-                  @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: message))
+                  @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: { result: { msg: message } }))
                 end
               ensure
                 @run = @backend.relay_api.put_run_state(@run)

--- a/lib/puppet_x/relay/agent/job/exec.rb
+++ b/lib/puppet_x/relay/agent/job/exec.rb
@@ -65,18 +65,20 @@ module PuppetX
               begin
                 @run = @backend.exec(@run, @state_dir, sched)
               rescue NotImplementedError => e
-                Puppet.log_exception(e, _('The backend %{backend_name} does not support the configuration for run %{id}: %{message}') % {
+                message = _('The backend %{backend_name} does not support the configuration for run %{id}: %{message}') % {
                   backend_name: @backend.class.name,
                   id: @run.id,
                   message: e.message,
-                })
-                @run = @run.with_state(@run.state.to_complete(outcome: 'error'))
+                }
+                Puppet.log_exception(e, message)
+                @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: exception))
               rescue StandardError => e
-                Puppet.log_exception(e, _('Run %{id} encountered an error during execution: %{message} (%{retries} retries remaining)') % { id: @run.id, message: e.message, retries: @retries })
+                message = _('Run %{id} encountered an error during execution: %{message} (%{retries} retries remaining)') % { id: @run.id, message: e.message, retries: @retries }
+                Puppet.log_exception(e, message)
 
                 if (@retries -= 1) < 0
                   Puppet.warning(_('Retries exhausted for run %{id}, transitioning to complete with error outcome') % { id: @run.id })
-                  @run = @run.with_state(@run.state.to_complete(outcome: 'error'))
+                  @run = @run.with_state(@run.state.to_complete(outcome: 'error', run_results: message))
                 end
               ensure
                 @run = @backend.relay_api.put_run_state(@run)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-relay",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": "Hunter Haugen",
   "summary": "Configure Puppet to work with Relay",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR modifies relay agent to return Orchestrator errors back to the Relay API, instead of throwing an exception.
The error is returned in `run_results` as follows:

`${outputs.'run-wait'.'results'}`

```json
{
  "error": "Failed to send request to orchestrator API",
  "message": "400 \"Bad Request\"",
  "response": {
    "details": {
      "parameter": "action",
      "type": "Enum[get, set, delete]",
      "value": "foo"
    },
    "kind": "puppetlabs.validators/validation-error",
    "msg": "The action parameter expected a value of type Enum[get, set, delete] but got \"foo\""
  }
}
```