### PR TITLE
Allow sensitive array type for relay_trigger_token

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class relay (
   Optional[Boolean] $test = undef,
   Optional[Stdlib::HTTPUrl] $relay_api_url = undef,
   Optional[Sensitive[String]] $relay_connection_token = undef,
-  Optional[Variant[Array[Sensitive[String]], Sensitive[String]]] $relay_trigger_token = undef,
+  Optional[Variant[Sensitive[Array[String]], Sensitive[String]]] $relay_trigger_token = undef,
   Optional[String] $proxy_host = undef,
   Optional[Integer] $proxy_port = undef,
   Optional[String] $proxy_user = undef,

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -3,7 +3,7 @@
   Optional[Boolean] $test,
   Optional[Stdlib::HTTPUrl] $relay_api_url,
   Optional[Sensitive[String]] $relay_connection_token,
-  Optional[Variant[Array[Sensitive[String]], Sensitive[String]]] $relay_trigger_token,
+  Optional[Variant[Sensitive[Array[String]], Sensitive[String]]] $relay_trigger_token,
   String $backend,
   Hash[String, Variant[Data, Sensitive[Data]]] $backend_options,
   Optional[String] $proxy_host,

--- a/templates/settings.yaml.epp
+++ b/templates/settings.yaml.epp
@@ -18,13 +18,7 @@
   'test' => $test,
   'relay_api_url' => $relay_api_url,
   'relay_connection_token' => $relay_connection_token.then |$t| { $t.unwrap },
-  'relay_trigger_token' => $relay_trigger_token.then |$ts| {
-    if $ts =~ Array[Sensitive[String]] {
-      $ts.map |$t| { $t.unwrap }
-    } else {
-      $ts.unwrap
-    }
-  },
+  'relay_trigger_token' => $relay_trigger_token.then |$ts| { $ts.unwrap },
   'backend' => $backend,
 } + Hash($backend_options.map |$key, $value| {
   [


### PR DESCRIPTION
This PR fixes the expected type in case the `relay_trigger_token` is an array.